### PR TITLE
Revert impl traits and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,36 @@
+sudo: false
 language: rust
+
+# Run builds for all the trains (and more)
 rust:
-- 1.1.0
-- 1.2.0
-- beta
-- nightly
+  - nightly
+  - beta
+  - stable
+  # Minimum usable version of rust required.
+  - 1.1.0
+
+# Load travis-cargo
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+
 os:
-- linux
+  - linux
+
 script:
-- cargo build --verbose
-- cargo test --verbose
-- cargo doc
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo bench &&
+      travis-cargo --only stable doc
+
 notifications:
   email:
     on_success: never
+
+
 env:
   global:
-  - secure: fjaqUKTiwvw4jlrgDtEWhawPZ3nybz9KeS+o5hs/KADSc3O7O/FCGNkuPeDEixLRGiS31gfM4+yPQRF40MAHRYda495Q4SEdd4yFA4jJebZUq85S6vlbg/YgNNzN6becdTV3VtfnDg/RcHpz8wS42lkXwq6LGCoWrh8GU8BGr8t//EcBYd8yQ/ihS6OBUm1BLe6oQc7/FRl0CSA65orh3NwXmytY2dOMG2nquk/WZDQaBLDw8Metfdz3y4mjGTLNPEnfaYEie43yxII0SS1C+KM3Bqqj6mx5dtUTMIE91u4k2IQNbbAZjQXSfDJfVeSX3rPyTQx0v7lFhBUlrL0NMS59/hrbpMJIxg7Kfg4FsFh9ttb2yU0IQBfbSMjFOpUyA0WmwWjmNruh5bkdiSO1ueyk5Sv9fmt7j8oGRH5gwpYfOovRrTa4GZ4HheNT2xmAtnw+jD3OPoSzHXpmKJdn7xSpT9vD0tepvu0poxqwekKtBgY4FGbCk40sL2s1y9c4O+NUv+ZtBujEs5L9kpIgMrKdXbanU343kwbDNnyesg80pPBPwvQ2W+6ZBg/Klgf7DUwuM1UcgJ6CcHOvXO3TdWuCpeWilD2uxIUZaiVYnXL26YgRoX7cZfLxH126m/q7gI3cgYg/gJmsHUVq1Djcn8Oz83J4PU+Ckm0KfJgvTDo=
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  echo '<meta http-equiv=refresh content=0;url=procure/index.html>' > target/doc/index.html &&
-  pip install ghp-import --user $USER &&
-  $HOME/.local/bin/ghp-import -n target/doc &&
-  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+    # Override the default `--features unstable` used for the nightly branch
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
 rust:
+- 1.1.0
+- 1.2.0
+- beta
 - nightly
 os:
 - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "procure"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Gary M. Josack <gary@byoteki.com>"]
-repository = "https://github.com/getprocure/procure"
-documentation = "http://getprocure.github.io/procure"
-license = "Apache-2.0"
+repository = "https://github.com/ZeroCostGoods/procure"
+documentation = "https://docs.rs/procure"
+license = "MIT OR Apache-2.0"
 description = "Rust Library for interfacing with /proc"
 
 [dependencies]
-sysconf = "*"
+sysconf = "0.1"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Gary M. Josack
+   Copyright 2015 procure Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 procure Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # procure
-[![Build Status](https://travis-ci.org/getprocure/procure.svg?branch=master)](https://travis-ci.org/getprocure/procure)
+[![Build Status](https://travis-ci.org/ZeroCostGoods/procure.svg?branch=master)](https://travis-ci.org/ZeroCostGoods/procure)
 [![Crates.io](https://img.shields.io/crates/v/procure.svg)](https://crates.io/crates/procure)
+[![Docs](https://docs.rs/procure/badge.svg)](https://docs.rs/procure)
 
-### Description
+## Description
 Rust Library for interfacing various stat sources on Linux such as /proc, /sys, etc.
 
-### Usage
+## Usage
 
 Add this to your `Cargo.toml`:
 
@@ -20,6 +21,21 @@ and this to your crate root:
 extern crate procure;
 ```
 
-### Documentation
+## Documentation
 
-Head over to http://getprocure.github.io/procure for the documentation.
+Head over to https://docs.rs/procure for the documentation.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 //! Procure is a library for grabbing various types of metrics from a
 //! Linux system.
 
-#![feature(conservative_impl_trait)]
-
 // Externs
 extern crate sysconf;
 


### PR DESCRIPTION
Don't use impl traits so I can target stable builds.